### PR TITLE
fix: Change callback to stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,44 +137,44 @@ Initialization configuration
 final _flutterShazamKitPlugin = FlutterShazamKit();
 
 @override
-  void initState() {
-    super.initState();
-    _flutterShazamKitPlugin
-        .configureShazamKitSession(developerToken: developerToken);
-  }
+void initState() {
+  super.initState();
+  _flutterShazamKitPlugin
+      .configureShazamKitSession(developerToken: developerToken);
+}
 
 @override
-  void dispose() {
-    super.dispose();
-    _flutterShazamKitPlugin.endSession();
-  }
+void dispose() {
+  super.dispose();
+  _flutterShazamKitPlugin.endSession();
+}
 ```
 
 Listen for the matching event
 
 ```dart
-_flutterShazamKitPlugin.onMatchResultDiscovered((result) {
-        if (result is Matched) {
-          print(result.mediaItems)
-        } else if (result is NoMatch) {
-          // do something in no match case
-        }
+_flutterShazamKitPlugin.matchResultDiscoveredStream.listen((result) {
+  if (result is Matched) {
+    print(result.mediaItems);
+  } else if (result is NoMatch) {
+    // do something in no match case
+  }
 });
 ```
 
 Listen for detecting state changed
 
 ```dart
-_flutterShazamKitPlugin.onDetectStateChanged((state) {
-        print(state)
+_flutterShazamKitPlugin.detectStateChangedStream.listen((state) {
+  print(state);
 });
 ```
 
 Listen for errors
 
 ```dart
-_flutterShazamKitPlugin.onError((error) {
-        print(error.message);
+_flutterShazamKitPlugin.errorStream.listen((error) {
+  print(error.message);
 });
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,7 +25,7 @@ class _MyAppState extends State<MyApp> {
     super.initState();
     _flutterShazamKitPlugin
         .configureShazamKitSession(developerToken: developerToken)
-        .then((value) {
+        .then((_) {
       _flutterShazamKitPlugin.onMatchResultDiscovered((result) {
         if (result is Matched) {
           setState(() {
@@ -158,11 +158,11 @@ class _MyAppState extends State<MyApp> {
         }));
   }
 
-  startDetect() {
+  void startDetect() {
     _flutterShazamKitPlugin.startDetectionWithMicrophone();
   }
 
-  endDetect() {
+  void endDetect() {
     _flutterShazamKitPlugin.endDetectionWithMicrophone();
   }
 }

--- a/lib/flutter_shazam_kit.dart
+++ b/lib/flutter_shazam_kit.dart
@@ -1,6 +1,9 @@
 library flutter_shazam_kit;
 
 import 'flutter_shazam_kit_platform_interface.dart';
+import 'models/detecting_state.dart';
+import 'models/error.dart';
+import 'models/result.dart';
 
 export './models/detecting_state.dart';
 export './models/error.dart';
@@ -8,20 +11,13 @@ export './models/media_item.dart';
 export '/models/result.dart';
 
 class FlutterShazamKit {
-  void onMatchResultDiscovered(
-      OnMatchResultDiscovered onMatchResultDiscovered) {
-    return FlutterShazamKitPlatform.instance
-        .onMatchResultDiscovered(onMatchResultDiscovered);
-  }
+  Stream<MatchResult> get matchResultDiscoveredStream =>
+      FlutterShazamKitPlatform.instance.matchResultDiscoveredStream;
 
-  void onDetectStateChanged(OnDetectStateChanged onDetectStateChanged) {
-    return FlutterShazamKitPlatform.instance
-        .onDetectStateChanged(onDetectStateChanged);
-  }
+  Stream<DetectState> get detectStateChangedStream =>
+      FlutterShazamKitPlatform.instance.detectStateChangedStream;
 
-  void onError(OnError onError) {
-    return FlutterShazamKitPlatform.instance.onError(onError);
-  }
+  Stream<MainError> get errorStream => FlutterShazamKitPlatform.instance.errorStream;
 
   Future<void> configureShazamKitSession({String? developerToken}) {
     return FlutterShazamKitPlatform.instance

--- a/lib/flutter_shazam_kit.dart
+++ b/lib/flutter_shazam_kit.dart
@@ -23,20 +23,20 @@ class FlutterShazamKit {
     return FlutterShazamKitPlatform.instance.onError(onError);
   }
 
-  Future configureShazamKitSession({String? developerToken}) {
+  Future<void> configureShazamKitSession({String? developerToken}) {
     return FlutterShazamKitPlatform.instance
         .configureShazamKitSession(developerToken: developerToken);
   }
 
-  Future startDetectionWithMicrophone() {
+  Future<void> startDetectionWithMicrophone() {
     return FlutterShazamKitPlatform.instance.startDetectionWithMicrophone();
   }
 
-  Future endDetectionWithMicrophone() {
+  Future<void> endDetectionWithMicrophone() {
     return FlutterShazamKitPlatform.instance.endDetectionWithMicrophone();
   }
 
-  Future endSession() {
+  Future<void> endSession() {
     return FlutterShazamKitPlatform.instance.endSession();
   }
 }

--- a/lib/flutter_shazam_kit_method_channel.dart
+++ b/lib/flutter_shazam_kit_method_channel.dart
@@ -56,7 +56,7 @@ class MethodChannelFlutterShazamKit extends FlutterShazamKitPlatform {
   }
 
   @override
-  Future configureShazamKitSession({String? developerToken}) {
+  Future<void> configureShazamKitSession({String? developerToken}) {
     return methodChannel.invokeMethod(
         "configureShazamKitSession",
         developerToken != null && Platform.isAndroid
@@ -65,7 +65,7 @@ class MethodChannelFlutterShazamKit extends FlutterShazamKitPlatform {
   }
 
   @override
-  Future endSession() {
+  Future<void> endSession() {
     onMatchResultDiscoveredCallback = null;
     onDetectStateChangedCallback = null;
     onErrorCallback = null;
@@ -89,14 +89,14 @@ class MethodChannelFlutterShazamKit extends FlutterShazamKitPlatform {
   }
 
   @override
-  Future startDetectionWithMicrophone() {
+  Future<void> startDetectionWithMicrophone() {
     return methodChannel.invokeMethod(
       "startDetectionWithMicrophone",
     );
   }
 
   @override
-  Future endDetectionWithMicrophone() {
+  Future<void> endDetectionWithMicrophone() {
     return methodChannel.invokeMethod("endDetectionWithMicrophone");
   }
 }

--- a/lib/flutter_shazam_kit_method_channel.dart
+++ b/lib/flutter_shazam_kit_method_channel.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
@@ -18,6 +19,12 @@ class MethodChannelFlutterShazamKit extends FlutterShazamKitPlatform {
   final callbackMethodChannel =
       const MethodChannel("flutter_shazam_kit_callback");
 
+  StreamController<MatchResult> matchResultDiscoveredController =
+      StreamController.broadcast();
+  StreamController<MainError> errorController = StreamController.broadcast();
+  StreamController<DetectState> detectStateChangedController =
+      StreamController.broadcast();
+
   MethodChannelFlutterShazamKit() {
     callbackMethodChannel.setMethodCallHandler(_nativeMethodHandler);
   }
@@ -27,18 +34,18 @@ class MethodChannelFlutterShazamKit extends FlutterShazamKitPlatform {
       case "matchFound":
         List<MediaItem> items =
             _parseMediaItemsFromJsonString(call.arguments as String? ?? "");
-        onMatchResultDiscoveredCallback?.call(Matched(mediaItems: items));
+        matchResultDiscoveredController.add(Matched(mediaItems: items));
         break;
       case "notFound":
-        onMatchResultDiscoveredCallback?.call(NoMatch());
+        matchResultDiscoveredController.add(NoMatch());
         break;
       case "didHasError":
         String errorMessage = call.arguments;
-        onErrorCallback?.call(MainError(message: errorMessage));
+        errorController.add(MainError(message: errorMessage));
         break;
       case "detectStateChanged":
         int stateIndex = call.arguments as int? ?? 0;
-        onDetectStateChangedCallback?.call(DetectState.values[stateIndex]);
+        detectStateChangedController.add(DetectState.values[stateIndex]);
         break;
     }
   }
@@ -66,27 +73,19 @@ class MethodChannelFlutterShazamKit extends FlutterShazamKitPlatform {
 
   @override
   Future<void> endSession() {
-    onMatchResultDiscoveredCallback = null;
-    onDetectStateChangedCallback = null;
-    onErrorCallback = null;
     return methodChannel.invokeMethod("endSession");
   }
 
   @override
-  void onMatchResultDiscovered(
-      OnMatchResultDiscovered onMatchResultDiscovered) {
-    onMatchResultDiscoveredCallback = onMatchResultDiscovered;
-  }
+  Stream<MatchResult> get matchResultDiscoveredStream =>
+      matchResultDiscoveredController.stream;
 
   @override
-  void onDetectStateChanged(OnDetectStateChanged onDetectStateChanged) {
-    onDetectStateChangedCallback = onDetectStateChanged;
-  }
+  Stream<DetectState> get detectStateChangedStream =>
+      detectStateChangedController.stream;
 
   @override
-  void onError(OnError onError) {
-    onErrorCallback = onError;
-  }
+  Stream<MainError> get errorStream => errorController.stream;
 
   @override
   Future<void> startDetectionWithMicrophone() {

--- a/lib/flutter_shazam_kit_platform_interface.dart
+++ b/lib/flutter_shazam_kit_platform_interface.dart
@@ -36,21 +36,21 @@ abstract class FlutterShazamKitPlatform extends PlatformInterface {
         'onDetectStateChanged() has not been implemented.');
   }
 
-  Future configureShazamKitSession({String? developerToken}) {
+  Future<void> configureShazamKitSession({String? developerToken}) {
     throw UnimplementedError(
         'configureShazamKitSession() has not been implemented.');
   }
 
-  Future endSession() {
+  Future<void> endSession() {
     throw UnimplementedError('endSession() has not been implemented.');
   }
 
-  Future startDetectionWithMicrophone() {
+  Future<void> startDetectionWithMicrophone() {
     throw UnimplementedError(
         'startDetectionWithMicrophone() has not been implemented.');
   }
 
-  Future endDetectionWithMicrophone() {
+  Future<void> endDetectionWithMicrophone() {
     throw UnimplementedError(
         'endDetectionWithMicrophone() has not been implemented.');
   }

--- a/lib/flutter_shazam_kit_platform_interface.dart
+++ b/lib/flutter_shazam_kit_platform_interface.dart
@@ -1,13 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter_shazam_kit/models/detecting_state.dart';
 import 'package:flutter_shazam_kit/models/error.dart';
 import 'package:flutter_shazam_kit/models/result.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'flutter_shazam_kit_method_channel.dart';
-
-typedef OnMatchResultDiscovered = Function(MatchResult);
-typedef OnError = Function(MainError error);
-typedef OnDetectStateChanged = Function(DetectState state);
 
 abstract class FlutterShazamKitPlatform extends PlatformInterface {
   /// Constructs a FlutterShazamKitPlatform.
@@ -17,24 +15,15 @@ abstract class FlutterShazamKitPlatform extends PlatformInterface {
 
   static FlutterShazamKitPlatform instance = MethodChannelFlutterShazamKit();
 
-  OnMatchResultDiscovered? onMatchResultDiscoveredCallback;
-  OnError? onErrorCallback;
-  OnDetectStateChanged? onDetectStateChangedCallback;
+  Stream<MatchResult> get matchResultDiscoveredStream =>
+      throw UnimplementedError(
+          'matchResultDiscoveredStream() has not been implemented.');
 
-  void onMatchResultDiscovered(
-      OnMatchResultDiscovered onMatchResultDiscovered) {
-    throw UnimplementedError(
-        'onMatchResultDiscovered() has not been implemented.');
-  }
+  Stream<MainError> get errorStream =>
+      throw UnimplementedError('errorStream() has not been implemented.');
 
-  void onError(OnError onError) {
-    throw UnimplementedError('onError() has not been implemented.');
-  }
-
-  void onDetectStateChanged(OnDetectStateChanged onDetectStateChanged) {
-    throw UnimplementedError(
-        'onDetectStateChanged() has not been implemented.');
-  }
+  Stream<DetectState> get detectStateChangedStream => throw UnimplementedError(
+      'detectStateChangedStream() has not been implemented.');
 
   Future<void> configureShazamKitSession({String? developerToken}) {
     throw UnimplementedError(


### PR DESCRIPTION
## Changes Made
- I've converted the callback event to a stream, which allows for more flexibility and better handling of asynchronous events.
- The new stream implementation allows for improved performance and easier handling of multiple events.
- The conversion of the callback event to a stream makes it possible to use standard Flutter stream-based APIs, such as `StreamBuilder` and `listen`.
- This change should make it easier to handle and respond to events in a consistent and predictable way.
